### PR TITLE
Fix: URI parameters now returns entire string;

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -6,7 +6,7 @@
                 "${workspaceFolder}/**"
             ],
             "defines": [],
-            "compilerPath": "/usr/sbin/clang",
+            "compilerPath": "/usr/bin/clang",
             "cStandard": "c17",
             "cppStandard": "c++17",
             "intelliSenseMode": "linux-clang-x64"

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -6,7 +6,7 @@
                 "${workspaceFolder}/**"
             ],
             "defines": [],
-            "compilerPath": "/usr/bin/clang",
+            "compilerPath": "/usr/sbin/clang",
             "cStandard": "c17",
             "cppStandard": "c++17",
             "intelliSenseMode": "linux-clang-x64"

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -192,7 +192,7 @@ int check_route(const char* method, const char* uri) {
                 return 0;
             }
 
-            strcpy(ext_uri_parameters[param_count], route_tokens[i] + 1);
+            strcpy(ext_uri_parameters[param_count], request_tokens[i]);
 
             param_count++;
         }


### PR DESCRIPTION
check_route (route_tokens + 1) to (request_tokens)

+1 was cutting the parameters off